### PR TITLE
Compatibility with Triton Inference Server

### DIFF
--- a/src/flexbench/main.py
+++ b/src/flexbench/main.py
@@ -29,6 +29,11 @@ def get_args():
         help="Model name on HuggingFace or local path",
     )
     parser.add_argument(
+        "--remote-model-path",
+        required=False,
+        help="Model name used to serve the model at the remote endpoint",
+    )
+    parser.add_argument(
         "--api-server",
         required=True,
         help="vLLM API server URL (default: http://localhost:8000)",
@@ -161,6 +166,7 @@ async def async_main() -> dict:
     benchmark_config = BenchmarkConfig(
         task=args.task,
         model_path=args.model_path,
+        remote_model_path=args.remote_model_path,
         tokenizer_path_override=args.tokenizer_path_override,
         api_server=args.api_server,
         api_token=args.api_token,

--- a/src/flexbench/runners/base.py
+++ b/src/flexbench/runners/base.py
@@ -30,6 +30,7 @@ class BenchmarkConfig:
     sweep_mode: bool = False
     num_sweep_points: int = 10
     tokenizer_path_override: str | None = None
+    remote_model_path: str | None = None
     api_token: str | None = None
     batch_size: int | None = None
     max_generated_tokens: int | None = None
@@ -69,6 +70,8 @@ class BenchmarkConfig:
             raise ValueError(
                 "Sweep mode is not compatible with accuracy testing. Use --target-qps for accuracy mode."
             )
+        if self.remote_model_path is None:
+            self.remote_model_path = self.model_path
 
 
 class BaseRunner(ABC):
@@ -169,7 +172,7 @@ class BaseBackend(ABC):
                     ),
                 },
                 json={
-                    "model": self.config.model_path,
+                    "model": self.config.remote_model_path,
                     "prompt": inputs,
                     "max_tokens": getattr(self, "max_tokens", 1024),
                     "temperature": 0,

--- a/src/flexbench/runners/vllm/backend.py
+++ b/src/flexbench/runners/vllm/backend.py
@@ -125,7 +125,7 @@ class VLLMBackend(BaseBackend):
             headers["Authorization"] = f"Bearer {self.config.api_token}"
 
         payload = {
-            "model": self.config.model_path,
+            "model": self.config.remote_model_path,
             "prompt": prompt,
             "max_tokens": query["max_tokens"],
             "temperature": 0,


### PR DESCRIPTION
Triton Inference Server model names have restrictions, we cannot directly use the HuggingFace label.

Adds another command line argument `--remote-model-path` (initializes to `--model-path` if not set), that is used as the model parameter in all remote API requests

Refs: ARCH-61