### PR TITLE
fix: --max-generated-tokens was not used in HTTP request, always defulted to 1024.

### DIFF
--- a/src/flexbench/runners/base.py
+++ b/src/flexbench/runners/base.py
@@ -95,7 +95,7 @@ class BaseBackend(ABC):
                 json={
                     "model": self.config.remote_model_path,
                     "prompt": inputs,
-                    "max_tokens": getattr(self, "max_tokens", 1024),
+                    "max_tokens": self.config.max_generated_tokens,
                     "temperature": 0,
                     "stream": stream,
                     "min_tokens": 1,


### PR DESCRIPTION
Refs: NOTICKET

Previously, the value provided via the `--max-generated-tokens` command-line option
was not being forwarded in the generated HTTP request. Instead, the `max_tokens` field in
the request JSON was always set to the default value of 1024. This fix ensures that
the specified parameter is correctly included in the request.